### PR TITLE
Fix code scanning alert no. 6: SQL query built from user-controlled sources

### DIFF
--- a/src/SimpleRDBMSRestfulAPI/Controllers/EntityController.cs
+++ b/src/SimpleRDBMSRestfulAPI/Controllers/EntityController.cs
@@ -85,8 +85,8 @@ public class EntityController(IAppSettings appSettings, IServiceProvider service
         var dbHelper = serviceProvider.GetRequiredKeyedService<IDataHelper>(connectonInfo.DbType);
         var queryData = dbHelper.BuildQuery(entityRequest);
 
-        var decodedQuery = HttpUtility.UrlDecode(query);
-        await sqlInjectionHelper.EnsureValid(decodedQuery);
+        queryData.query = HttpUtility.UrlDecode(queryData.query);
+        await sqlInjectionHelper.EnsureValid(queryData.query);
 
         var result = await dbHelper.GetData(connectonInfo, queryData);
         return Ok(result);

--- a/src/SimpleRDBMSRestfulAPI/Controllers/EntityController.cs
+++ b/src/SimpleRDBMSRestfulAPI/Controllers/EntityController.cs
@@ -83,12 +83,12 @@ public class EntityController(IAppSettings appSettings, IServiceProvider service
             throw new Exception("Please ask the API Owner to configure the database connection.");
         }
         var dbHelper = serviceProvider.GetRequiredKeyedService<IDataHelper>(connectonInfo.DbType);
-        string query = dbHelper.BuildQuery(entityRequest);
+        var queryData = dbHelper.BuildQuery(entityRequest);
 
         var decodedQuery = HttpUtility.UrlDecode(query);
         await sqlInjectionHelper.EnsureValid(decodedQuery);
 
-        var result = await dbHelper.GetData(connectonInfo, query, entityRequest.@params);
+        var result = await dbHelper.GetData(connectonInfo, queryData);
         return Ok(result);
     }
 }

--- a/src/SimpleRDBMSRestfulAPI/Controllers/SqlController.cs
+++ b/src/SimpleRDBMSRestfulAPI/Controllers/SqlController.cs
@@ -40,7 +40,7 @@ public class SqlController(IAppSettings appSettings, IServiceProvider servicePro
         }
 
         var dbHelper = serviceProvider.GetRequiredKeyedService<IDataHelper>(connectonInfo.DbType);
-        var result = await dbHelper.GetData(connectonInfo, decodedQuery, queryRequest.@params);
+        var result = await dbHelper.GetData(connectonInfo, (decodedQuery, queryRequest.@params));
         return Ok(result);
     }
 }

--- a/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/BaseDataHelper.cs
+++ b/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/BaseDataHelper.cs
@@ -4,6 +4,7 @@ using Dapper;
 using SimpleRDBMSRestfulAPI.Constants;
 using SimpleRDBMSRestfulAPI.Libs;
 using SimpleRDBMSRestfulAPI.Models;
+using SimpleRDBMSRestfulAPI.Settings;
 using DbType = SimpleRDBMSRestfulAPI.Constants.DbType;
 
 namespace SimpleRDBMSRestfulAPI.Helpers;
@@ -14,14 +15,14 @@ public abstract class BaseDataHelper : IDataHelper
 
     public abstract DbType DbType { get; }
 
-    public abstract (string query, Dictionary<string, object> parameters) BuildQuery(EntityRequestMetadata request);
+    public abstract (string query, IDictionary<string, object> parameters) BuildQuery(EntityRequestMetadata request);
     public abstract Task ConnectAsync(string connectionString);
 
     public abstract IDbConnection CreateConnection(string connectionString);
 
     public virtual async Task<IEnumerable<IDictionary<string, object>>> GetData(
         Settings.ConnectionInfoDTO connectonInfo,
-        (string query, Dictionary<string, object> parameters) queryData
+        (string query, IDictionary<string, object> parameters) queryData
     )
     {
         var convertedParams = queryData.parameters?.ToDictionary(
@@ -74,4 +75,5 @@ public abstract class BaseDataHelper : IDataHelper
                 return jsonElement.ToString();
         }
     }
+
 }

--- a/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/IDataHelper.cs
+++ b/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/IDataHelper.cs
@@ -7,12 +7,11 @@ namespace SimpleRDBMSRestfulAPI.Helpers;
 
 public interface IDataHelper
 {
-    string BuildQuery(EntityRequestMetadata request);
+    (string query, IDictionary<string, object> parameters) BuildQuery(EntityRequestMetadata request);
     Task ConnectAsync(string connectionString);
     public Task<IEnumerable<IDictionary<string, object>>> GetData(
         Settings.ConnectionInfoDTO connectonInfo,
-        string query,
-        Dictionary<string, object>? @params
+        (string query, IDictionary<string, object> parameters) queryData
     );
     string GetDatabase(byte[] encryptedConnectionString);
     string GetHost(byte[] encryptedConnectionString);

--- a/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/MySQLDataHelper.cs
+++ b/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/MySQLDataHelper.cs
@@ -21,7 +21,7 @@ public class MySqlDataHelper : BaseDataHelper
 
     public override DbType DbType => DbType.MYSQL;
 
-    public override string BuildQuery(EntityRequestMetadata request)
+    public override (string query, IDictionary<string, object> parameters) BuildQuery(EntityRequestMetadata request)
     {
         throw new NotImplementedException();
     }

--- a/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/OracleDataHelper.cs
+++ b/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/OracleDataHelper.cs
@@ -20,7 +20,7 @@ public class OracleDataHelper : BaseDataHelper
 
     public override DbType DbType => DbType.ORACLE;
 
-    public override string BuildQuery(EntityRequestMetadata request)
+    public override (string query, IDictionary<string, object> parameters) BuildQuery(EntityRequestMetadata request)
     {
         throw new NotImplementedException();
     }

--- a/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/PostgresDataHelper.cs
+++ b/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/PostgresDataHelper.cs
@@ -22,10 +22,9 @@ public class PostgresDataHelper : BaseDataHelper
 
     public override DbType DbType => DbType.POSTGRES;
 
-    public override string BuildQuery(EntityRequestMetadata request)
+    public override (string query, IDictionary<string, object> parameters) BuildQuery(EntityRequestMetadata request)
     {
-        Dictionary<string, object> @params = request.@params;
-        @params = @params ?? new Dictionary<string, object>();
+        Dictionary<string, object> @params = request.@params ?? new Dictionary<string, object>();
         if (!@params.ContainsKey("limit"))
         {
             throw new ArgumentNullException("The @limit param is required");
@@ -53,7 +52,7 @@ FROM {request.TableName}
 {request.OrderBy} 
 LIMIT @limit 
 OFFSET @offset";
-        return query.Trim();
+        return (query: query.Trim(), parameters: @params);
     }
 
     public override async Task ConnectAsync(string connectionString)

--- a/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/SQLAnywhereDataHelper.cs
+++ b/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/SQLAnywhereDataHelper.cs
@@ -20,7 +20,7 @@ public class SqlAnywhereDataHelper : BaseDataHelper
 
     public override DbType DbType => DbType.SQL_ANYWHERE;
 
-    public override string BuildQuery(EntityRequestMetadata request)
+    public override (string query, IDictionary<string, object> parameters) BuildQuery(EntityRequestMetadata request)
     {
         Dictionary<string, object> @params = request.@params ?? new Dictionary<string, object>();
         if (!@params.ContainsKey("top"))
@@ -51,7 +51,7 @@ public class SqlAnywhereDataHelper : BaseDataHelper
 FROM {request.TableName}
 {conditions}
 {request.OrderBy}";
-        return query.Trim();
+        return (query: query.Trim(), parameters: @params);
     }
 
     public override async Task ConnectAsync(string connectionString)

--- a/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/SQLServerDataHelper.cs
+++ b/src/SimpleRDBMSRestfulAPI/Helpers/RDBMS/SQLServerDataHelper.cs
@@ -19,7 +19,7 @@ public class SqlServerDataHelper : BaseDataHelper
 
     public override DbType DbType => DbType.SQL_SERVER;
 
-    public override string BuildQuery(EntityRequestMetadata request)
+    public override (string query, IDictionary<string, object> parameters) BuildQuery(EntityRequestMetadata request)
     {
         throw new NotImplementedException();
     }


### PR DESCRIPTION
Fixes [https://github.com/beehexacorp/simple-rdbms-rest-api/security/code-scanning/6](https://github.com/beehexacorp/simple-rdbms-rest-api/security/code-scanning/6)

The best way to fix the problem is to use parameterized queries instead of directly concatenating user input into the SQL query. This can be achieved by modifying the `BuildQuery` method to return a parameterized query and updating the `GetData` method to use these parameters.

1. Modify the `BuildQuery` method to return a parameterized query and a dictionary of parameters.
2. Update the `GetData` method to use the parameterized query and the parameters dictionary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
